### PR TITLE
✨엘라스틱 서치 인덱스에 데이터 컬럼 추가

### DIFF
--- a/src/main/java/com/kcs3/auction/document/ItemDocument.java
+++ b/src/main/java/com/kcs3/auction/document/ItemDocument.java
@@ -4,7 +4,9 @@ import lombok.Builder;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 
+import java.time.LocalDateTime;
+
 @Document(indexName = "items")
 @Builder
-public record ItemDocument(@Id Long itemId, String itemTitle) {
+public record ItemDocument(@Id Long itemId, String itemTitle, LocalDateTime createAt) {
 }

--- a/src/main/java/com/kcs3/auction/service/ItemService.java
+++ b/src/main/java/com/kcs3/auction/service/ItemService.java
@@ -194,6 +194,7 @@ public class ItemService {
         itemElasticsearchRepository.save(ItemDocument.builder()
                 .itemTitle(auctionProgressItem.getItemTitle())
                 .itemId(item.getItemId())
+                .createAt(item.getCreatedAt())
                 .build());
     }
 


### PR DESCRIPTION
✨엘라스틱 서치 인덱스에 생성일 컬럼 추가
---
엘라스틱 서치에 데이터 생성일 컬럼을 추가하고, 물품 등록 시 해당 컬럼에 물품 생성시간 데이터가 입력될 수 있도록 수정하였습니다. 